### PR TITLE
Replace `be` with `become`

### DIFF
--- a/rust.nanorc
+++ b/rust.nanorc
@@ -8,7 +8,7 @@ syntax "rust" "\.rs"
 color magenta "fn [a-z0-9_]+"
 
 # Reserved words
-color yellow "\<(abstract|alignof|as|be|box|break|const|continue|crate|do|else|enum|extern|false|final|fn|for|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|override|priv|pub|pure|ref|return|sizeof|static|self|struct|super|true|trait|type|typeof|unsafe|unsized|use|virtual|where|while|yield)\>"
+color yellow "\<(abstract|alignof|as|become|box|break|const|continue|crate|do|else|enum|extern|false|final|fn|for|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|override|priv|pub|pure|ref|return|sizeof|static|self|struct|super|true|trait|type|typeof|unsafe|unsized|use|virtual|where|while|yield)\>"
 
 # macros
 color red "[a-z_]+!"


### PR DESCRIPTION
The reserved keyword `be` has been replaced with `become` by
rust-lang/rust#21918.
