### PR TITLE
Add support for block comment highlighting

### DIFF
--- a/rust.nanorc
+++ b/rust.nanorc
@@ -27,6 +27,7 @@ color green start="r#+\"" end="\"#+"
 
 # Comments
 color blue "//.*"
+color blue start"/\*" end="\*/"
 
 # Attributes
 color magenta start="#!\[" end="\]"


### PR DESCRIPTION
Just copied this over from c.nanorc.
